### PR TITLE
Add specialized RetryError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backoff-decorator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backoff-decorator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Exponential retry backoff library offering full jitter and decorators.",
   "main": "dist/src/backoff.js",
   "types": "dist/src/backoff.d.ts",

--- a/src/backoff.ts
+++ b/src/backoff.ts
@@ -1,3 +1,5 @@
+export class RetryError extends Error {}
+
 /**
  * Generator for an exponentially increasing value of power of two,
  * multiplied by a factor, up to a maximum value.
@@ -102,7 +104,7 @@ export async function retry(
 
     numRetries++;
     if (numRetries > maxRetries) {
-      throw new Error(`Maximum of ${maxRetries} retries reached when calling target ${targetFunction.name}`);
+      throw new RetryError(`Maximum of ${maxRetries} retries reached when calling target ${targetFunction.name}`);
     }
     // sleep before retrying
     await sleepFunction(delayMs);

--- a/test/backoff_test.ts
+++ b/test/backoff_test.ts
@@ -119,6 +119,7 @@ describe('backoff', () => {
         assert(false, 'function should throw');
       } catch (err) {
         expect(err.message).to.match(/Maximum of 2 retries/);
+        expect(err).to.be.instanceof(Backoff.RetryError);
       }
     });
 


### PR DESCRIPTION
When the maximum number of retries is reached, throw an error of specialized type RetryError instead of generic Error. This eases the handling of the error.

Unit test was modified to check the type of the error thrown.