### PR TITLE
Throw original error when max retries reached.

### DIFF
--- a/test/backoff_test.ts
+++ b/test/backoff_test.ts
@@ -148,8 +148,7 @@ describe('backoff', () => {
         }, faultyCall);
         assert(false, 'function should throw');
       } catch (err) {
-        expect(err.message).to.match(/Maximum of 2 retries/);
-        expect(err).to.be.instanceof(Backoff.RetryError);
+        expect(err.message).to.match(/foo/);
       }
     });
 
@@ -198,7 +197,7 @@ describe('backoff', () => {
         await decotest.matchingCall();
         assert(false, 'function should throw');
       } catch (err) {
-        expect(err.message).to.match(/Maximum of 2 retries/);
+        expect(err.message).to.match(/foo/);
       }
     });
 
@@ -261,7 +260,7 @@ describe('backoff', () => {
         await decotest.matchingCall();
         assert(false, 'function should throw');
       } catch (err) {
-        expect(err.message).to.match(/Maximum of 3 retries/);
+        expect(err.message).to.match(/foo/);
         expect(decotest.numCalled).to.eql(3);
       }
     });


### PR DESCRIPTION
The fact that a `RetryError` was thrown instead of the original
error was preventing the library's user to do proper logging
on the cause of the error.