### PR TITLE
🐛🐛 Raise original error only when !predicate

### DIFF
--- a/src/backoff.ts
+++ b/src/backoff.ts
@@ -109,8 +109,8 @@ export async function retry(
       return result;
     } catch (err) {
       originalError = err;
-      if (!predicate || !predicate(err, args)) {
-        throw err;
+      if (!predicate || !predicate(originalError, args)) {
+        throw originalError;
       }
     }
 

--- a/test/backoff_test.ts
+++ b/test/backoff_test.ts
@@ -140,7 +140,7 @@ describe('backoff', () => {
       }
     });
 
-    it('throws an error if maxRetries is reached', async () => {
+    it('throws a RetryError if maxRetries is reached', async () => {
       try {
         await Backoff.retry({
           predicate: alwaysTrue,
@@ -148,7 +148,21 @@ describe('backoff', () => {
         }, faultyCall);
         assert(false, 'function should throw');
       } catch (err) {
-        expect(err.message).to.match(/foo/);
+        expect(err.message).to.match(/Maximum of 2 retries/);
+        expect(err).to.be.instanceof(Backoff.RetryError);
+      }
+    });
+
+    it('throws the original error if it does not match the predicate', async () => {
+      try {
+        await Backoff.retry({
+          predicate: alwaysFalse,
+          maxRetries: 2,
+        }, faultyCall);
+        assert(false, 'function should throw');
+      } catch (err) {
+        expect(err.message).not.to.match(/Maximum of 2 retries/);
+        expect(err).not.to.be.instanceof(Backoff.RetryError);
       }
     });
 
@@ -192,12 +206,12 @@ describe('backoff', () => {
       }
     });
 
-    it('throws an error if maxRetries is reached', async () => {
+    it('throws a RetryError if maxRetries is reached', async () => {
       try {
         await decotest.matchingCall();
         assert(false, 'function should throw');
       } catch (err) {
-        expect(err.message).to.match(/foo/);
+        expect(err.message).to.match(/Maximum of 2 retries/);
       }
     });
 
@@ -260,7 +274,7 @@ describe('backoff', () => {
         await decotest.matchingCall();
         assert(false, 'function should throw');
       } catch (err) {
-        expect(err.message).to.match(/foo/);
+        expect(err.message).to.match(/Maximum of 3 retries/);
         expect(decotest.numCalled).to.eql(3);
       }
     });

--- a/test/backoff_test.ts
+++ b/test/backoff_test.ts
@@ -163,6 +163,7 @@ describe('backoff', () => {
       } catch (err) {
         expect(err.message).not.to.match(/Maximum of 2 retries/);
         expect(err).not.to.be.instanceof(Backoff.RetryError);
+        expect(err.message).to.match(/foo/);
       }
     });
 

--- a/test/backoff_test.ts
+++ b/test/backoff_test.ts
@@ -207,15 +207,6 @@ describe('backoff', () => {
       }
     });
 
-    it('throws a RetryError if maxRetries is reached', async () => {
-      try {
-        await decotest.matchingCall();
-        assert(false, 'function should throw');
-      } catch (err) {
-        expect(err.message).to.match(/Maximum of 2 retries/);
-      }
-    });
-
   });
 
 


### PR DESCRIPTION
bringing back the `RetryError` that was removed in https://github.com/unitoio/backoff-decorator/pull/11.


We need to throw a `RetryError` when the max retries is reached and the error should've been retried. The original error is only thrown if it doesn't match the predicate (an "unexpected" error).

**We will need to update the dashboards (especially babylon) after this is merged.**